### PR TITLE
Add tags for UAP unifiIfTable and unifiVapTable

### DIFF
--- a/UniFi-UAP/telegraf-inputs.conf
+++ b/UniFi-UAP/telegraf-inputs.conf
@@ -112,12 +112,28 @@
      [[inputs.snmp.table.field]]
        is_tag = true
        oid = "UBNT-UniFi-MIB::unifiVapRadio"
+     [[inputs.snmp.table.field]]
+       is_tag = true
+       oid = "UBNT-UniFi-MIB::unifiVapEssId"
+     [[inputs.snmp.table.field]]
+       is_tag = true
+       oid = "UBNT-UniFi-MIB::unifiVapBssId"
+     [[inputs.snmp.table.field]]
+       is_tag = true
+       oid = "UBNT-UniFi-MIB::unifiVapUsage"
+
    #  Ethernet interfaces
    [[inputs.snmp.table]]
      oid = "UBNT-UniFi-MIB::unifiIfTable"
      [[inputs.snmp.table.field]]
        is_tag = true
        oid = "UBNT-UniFi-MIB::unifiIfName"
+     [[inputs.snmp.table.field]]
+       is_tag = true
+       oid = "UBNT-UniFi-MIB::unifiIfIp"
+     [[inputs.snmp.table.field]]
+       is_tag = true
+       oid = "UBNT-UniFi-MIB::unifiIfMac"
    ##
    ## System Performance
    ##


### PR DESCRIPTION
I think these are really more useful as tags and not fields, and should allow for filtering by wifi network name (essid).